### PR TITLE
fix pip install error no such file requirements.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include CHANGELOG.md
 include LICENSE
 include VERSION
 include README.md
+include requirements.txt
 
 recursive-include tests *
 recursive-exclude * __pycache__


### PR DESCRIPTION
@erichiggins I found your project and would like to use it in my project.  When trying to install using pip I get the following error:

Collecting gaek
  Using cached gaek-0.1.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/private/var/folders/p9/8k6_j0bd66g4lysl6bckxcdh0000gn/T/pip-build-3nfmnI/gaek/setup.py", line 12, in <module>
        with open('requirements.txt') as requirements_file:
    IOError: [Errno 2] No such file or directory: 'requirements.txt'

I researched this error and determined that this should fix the problem.  Let me know what you think
