### PR TITLE
Add recursive-include *.txt to MANIFEST.in for package installs.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,5 +6,5 @@ include README.md
 recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
-
+recursive-include *.txt
 recursive-include * *.rst *.md


### PR DESCRIPTION
So it picks up both `requirements.txt` and `test_requirements.txt`
