### PR TITLE
Clean up requirements. Fix bug in is_default_version

### DIFF
--- a/gaek/environ.py
+++ b/gaek/environ.py
@@ -3,23 +3,25 @@
 Environment discovery and helper functions for Google App Engine.
 Some methods from the following modules have been made available for convenience:
 
-* [`google.appengine.api.app_identity`](https://cloud.google.com/appengine/docs/python/appidentity/)
-* [`google.appengine.api.modules`](https://cloud.google.com/appengine/docs/python/modules/)
-* [`google.appengine.api.namespace_manager`](https://cloud.google.com/appengine/docs/python/multitenancy/)
+* google.appengine.api.app_identity
+  https://cloud.google.com/appengine/docs/python/appidentity/
+* google.appengine.api.modules
+  https://cloud.google.com/appengine/docs/python/modules/
+* google.appengine.api.namespace_manager
+  https://cloud.google.com/appengine/docs/python/multitenancy/
 
 Example:
 
-  import environ
+  import gaek.environ
 
   # Only send emails in production.
-  if environ.is_production():
+  if gaek.environ.is_production():
     mail.send(*args, **kwargs)
   
 """
  
 __author__ = 'Eric Higgins'
 __copyright__ = 'Copyright 2015, Eric Higgins'
-__version__ = '0.0.1'
 __email__ = 'erichiggins@gmail.com'
 
 
@@ -92,7 +94,7 @@ def is_host_google():
 def is_default_version(version=None):
   """True if the current or specified app version is the default."""
   version = version or get_current_version_name()
-  return get_current_version_name() == get_default_version()
+  return version == get_default_version()
 
 
 def is_development():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 python-dateutil>=2.4.2
-PyYAML~=3.10

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,0 @@
-python-dateutil>=2.4.2
-PyYAML==3.10


### PR DESCRIPTION
One line in `requirements.txt` prevents 0.2.2 from being installed via pip.
Discovered a bug in `is_default_version` that it didn't use the `version` parameter, which is used by many other functions provided in `environ`.
