### PR TITLE
Handle deprecation of namespace_manager API

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-GAE_SDK_SHA1='abe54d95c4ce6ffc35452e027ca701f5d21dd56a'
-GAE_SDK_FILE='google_appengine_1.9.35.zip'
+GAE_SDK_SHA1='35c6857852f787ab777824ceaf645964cff696bc'
+GAE_SDK_FILE='google_appengine_1.9.88.zip'
 
 # Create virtual environment.
 echo 'Creating virtual environment...'
@@ -22,10 +22,14 @@ unzip -q $GAE_SDK_FILE -d .dev_env/
 rm $GAE_SDK_FILE
 
 # Travis CI uses a different path.
-cd .dev_env/site-packages/
-ln -s ../google_appengine/google google
+if [ -d ".dev_env/site-packages/" ]; then
+  cd .dev_env/site-packages/
+  ln -s ../google_appengine/google google
+fi
 
 # OSX path.
-cd .dev_env/lib/python2.7/site-packages/
-ln -s ../../../google_appengine/google google
-cd ../../../../
+if [ -d ".dev_env/lib/python2.7/site-packages/" ]; then
+  cd .dev_env/lib/python2.7/site-packages/
+  ln -s ../../../google_appengine/google google
+  cd ../../../../
+fi


### PR DESCRIPTION
Prepare for the upcoming removal/deprecation of the `namespace_manager` API & module as described in #30 and #20 

Note: This PR also upgrades the GAE SDK to the latest version.